### PR TITLE
Revise Benchmark ABI description: bounds are retained everywhere but PCC.

### DIFF
--- a/src/performance-methodology/abis-code-generation-and-compilation.md
+++ b/src/performance-methodology/abis-code-generation-and-compilation.md
@@ -22,11 +22,11 @@ substantial tax on dynamic performance when capability protections are applied
 to control flow.
 
 To work around this behavior, we have developed a *Benchmark ABI*, which uses
-global bounds for all code pointers, including the base program binary (as
-passed to userlevel via registers and ELF auxiliary arguments) and libraries
-(as returned by mmap(2) and manipulated by the run-time linker), and that are
-jumped to using integer jump instructions rather than capability jump
-instructions.
+global bounds for the program counter capability (PCC) throughout execution.
+In-memory and in-register code capability values retain narrowed bounds (e.g.,
+those set up by the run-time linker), but code generation uses integer rather
+than capability jumps, retaining global bounds in PCC regardless of control
+flow.
 In effect, this ABI substantially reduces control-flow protections and
 encapsulation in return for more effective branch-prediction on the Morello
 microarchitecture, which is likely to be representative of more mature future

--- a/src/performance-methodology/abis-code-generation-and-compilation.md
+++ b/src/performance-methodology/abis-code-generation-and-compilation.md
@@ -24,7 +24,7 @@ to control flow.
 To work around this behavior, we have developed a *Benchmark ABI*, which uses
 global bounds for the program counter capability (PCC) and any return
 capabilities throughout execution.
-All other n-memory and in-register code capability values retain narrowed
+All other in-memory and in-register code capability values retain narrowed
 bounds (e.g., those set up by the run-time linker), but code generation uses
 integer rather than capability jumps, retaining global bounds in PCC
 regardless of control flow.

--- a/src/performance-methodology/abis-code-generation-and-compilation.md
+++ b/src/performance-methodology/abis-code-generation-and-compilation.md
@@ -22,11 +22,12 @@ substantial tax on dynamic performance when capability protections are applied
 to control flow.
 
 To work around this behavior, we have developed a *Benchmark ABI*, which uses
-global bounds for the program counter capability (PCC) throughout execution.
-In-memory and in-register code capability values retain narrowed bounds (e.g.,
-those set up by the run-time linker), but code generation uses integer rather
-than capability jumps, retaining global bounds in PCC regardless of control
-flow.
+global bounds for the program counter capability (PCC) and any return
+capabilities throughout execution.
+All other n-memory and in-register code capability values retain narrowed
+bounds (e.g., those set up by the run-time linker), but code generation uses
+integer rather than capability jumps, retaining global bounds in PCC
+regardless of control flow.
 In effect, this ABI substantially reduces control-flow protections and
 encapsulation in return for more effective branch-prediction on the Morello
 microarchitecture, which is likely to be representative of more mature future


### PR DESCRIPTION
The existing description indicated that bounds were left global in all capabilities. In fact, we leave bounds as-is everywhere except PCC.

NB: ... and return capabilities?