### PR TITLE
Phrase about incorporation into the baseline refers to jump tables.

### DIFF
--- a/src/performance-analysis-spec/specific-hardware-and-software.md
+++ b/src/performance-analysis-spec/specific-hardware-and-software.md
@@ -26,8 +26,7 @@ Further, all global accesses are via the GOT, to ensure every global is
 accessed through a dedicated capability carrying variable-specific permissions
 and bounds.
 This configuration is known to trigger the PCC branch-prediction issue during
-calls into short functions, function returns, and jump tables &mdash; a change
-that is now also used in baseline pure-capability code generation.
+calls into short functions, function returns, and jump tables.
 
 ## Benchmark ABI (w/o data-dependency fix) (w/o larger store queue)
 
@@ -39,7 +38,8 @@ avoiding triggering of stalls stemming from PCC-relative accesses depending on
 new PCC bounds as described in [Morello microarchitectural
 limitations](../performance-methodology/morello-microarchitectural-limitations.md).
 This workaround should especially recover non-essential overhead associated
-with jump tables and calls into short functions.
+with jump tables and calls into short functions &mdash; a change that is now
+also used in baseline pure-capability code generation.
 
 ## Benchmark ABI (w/ data-dependency fix) (w/o larger store queue)
 

--- a/src/performance-analysis-spec/specific-hardware-and-software.md
+++ b/src/performance-analysis-spec/specific-hardware-and-software.md
@@ -27,7 +27,7 @@ accessed through a dedicated capability carrying variable-specific permissions
 and bounds.
 This configuration is known to trigger the PCC branch-prediction issue during
 calls into short functions and function returns.
-Jump tables are implemented integer jumps and so do not suffer from this
+Jump tables are implemented as integer jumps and so do not suffer from this
 issue, but would if they used capability-relative jumps.
 
 ## Benchmark ABI (w/o data-dependency fix) (w/o larger store queue)

--- a/src/performance-analysis-spec/specific-hardware-and-software.md
+++ b/src/performance-analysis-spec/specific-hardware-and-software.md
@@ -26,7 +26,9 @@ Further, all global accesses are via the GOT, to ensure every global is
 accessed through a dedicated capability carrying variable-specific permissions
 and bounds.
 This configuration is known to trigger the PCC branch-prediction issue during
-calls into short functions, function returns, and jump tables.
+calls into short functions and function returns.
+Jump tables are implemented integer jumps and so do not suffer from this
+issue, but would if they used capability-relative jumps.
 
 ## Benchmark ABI (w/o data-dependency fix) (w/o larger store queue)
 
@@ -38,8 +40,7 @@ avoiding triggering of stalls stemming from PCC-relative accesses depending on
 new PCC bounds as described in [Morello microarchitectural
 limitations](../performance-methodology/morello-microarchitectural-limitations.md).
 This workaround should especially recover non-essential overhead associated
-with jump tables and calls into short functions &mdash; a change that is now
-also used in baseline pure-capability code generation.
+with calls into short functions.
 
 ## Benchmark ABI (w/ data-dependency fix) (w/o larger store queue)
 


### PR DESCRIPTION
@nwf points out that this clause about incorporation of a change back into baseline code generation is not in the right place; move it from the baseline description to the benchmark ABI description.